### PR TITLE
Updates of Dockerfile nameindex version and their directory location in configurations

### DIFF
--- a/ala-sensitive-data-server/docker/Dockerfile
+++ b/ala-sensitive-data-server/docker/Dockerfile
@@ -17,8 +17,8 @@ RUN echo "deb [arch=amd64] https://apt.gbif.es/ bionic main" > /etc/apt/sources.
 # Install main dependencies
 RUN apt-get install -y -q openjdk-8-jdk tar curl
 
-RUN echo "ala-namematching-service ala-namematching-service/source string https://archives.ala.org.au/archives/nameindexes/20210811/namematching-20210811.tgz" | debconf-set-selections
-RUN echo "ala-namematching-service ala-namematching-service/sha1 string 563814a7b5d886b746e10eb40c44f0d9bda62371" | debconf-set-selections
+RUN echo "ala-namematching-service ala-namematching-service/source string https://archives.ala.org.au/archives/nameindexes/latest/namematching-20200214.tgz" | debconf-set-selections
+RUN echo "ala-namematching-service ala-namematching-service/sha1 string f9e42325db8d41ca0c8afeb6aeadf670978a13ac" | debconf-set-selections
 
 RUN echo "ala-sensitive-data-service ala-sensitive-data-service/sds-url string https://sds.ala.org.au" | debconf-set-selections
 RUN echo "ala-sensitive-data-service ala-sensitive-data-service/spatial-url string https://spatial.ala.org.au" | debconf-set-selections

--- a/ala-sensitive-data-server/docker/config.yml
+++ b/ala-sensitive-data-server/docker/config.yml
@@ -20,7 +20,7 @@ server:
     - type: http
       port: 9190
 conservation:
-  index: /data/lucene/namematching-20200214
+  index: /data/lucene/namematching
   speciesUrl: file:///data/sds/sensitive-species-data.xml
   zonesUrl: file:///data/sds/sensitivity-zones.xml
   categoriesUrl: file:///data/sds/sensitivity-categories.xml

--- a/ala-sensitive-data-server/docker/sds-config.properties
+++ b/ala-sensitive-data-server/docker/sds-config.properties
@@ -1,4 +1,4 @@
 zone-data=file:///data/sds/sensitivity-zones.xml
 species-data=file:///data/sds/sensitive-species.xml
 category-data=file:///data/sds/sensitivity-categories.xml
-namematching-index=/data/lucene/namematching-20200214
+namematching-index=/data/lucene/namematching


### PR DESCRIPTION
After [this conversation](
https://atlaslivingaustralia.slack.com/archives/CCTFGEU1G/p1637018341118100?thread_ts=1636964757.102400&cid=CCTFGEU1G) I realized that the `Dockerfile-test` (the previous one) is using a different `nameindex` so I restored it.

Also as the `Dockerfile` and the debian package uses `/data/lucene/namematching` I setup this in the configurations.