### PR TITLE
Update ala-sensitive-data-service.postinst with --no-same-owner

### DIFF
--- a/debian/ala-sensitive-data-service.postinst
+++ b/debian/ala-sensitive-data-service.postinst
@@ -46,7 +46,7 @@ case "$1" in
         echo "Extracting SDS layers..."
         # SDS def ALA tgz is created with a MacOS tar
         # https://github.com/yarnpkg/yarn/issues/770
-        tar --warning=no-unknown-keyword -zxf /data/biocache/layers/sds-layers.tgz -C /data/biocache/layers/
+        tar --no-same-owner --warning=no-unknown-keyword -zxf /data/biocache/layers/sds-layers.tgz -C /data/biocache/layers/
 
         chown -R sds-data:sds-data /opt/atlas/ala-sensitive-data-service
 


### PR DESCRIPTION
The current `sds-layers.tgz` untar fails in some VMs with errors like:
```
(...)
tar: sqz_ts.shp: Cannot change ownership to uid 1847169192, gid 0: Invalid argument
tar: sqz_ts.shx: Cannot change ownership to uid 1847169192, gid 0: Invalid argument
tar: world.dbf: Cannot change ownership to uid 1847169192, gid 0: Invalid argument
tar: world.prj: Cannot change ownership to uid 1847169192, gid 0: Invalid argument
tar: world.shp: Cannot change ownership to uid 1847169192, gid 0: Invalid argument
tar: world.shx: Cannot change ownership to uid 1847169192, gid 0: Invalid argument
(...)
```
this was working in previous versions of `sds-layers` I think. 

This PR adds a `--no-same-owner` option to tar to prevent this error.