### PR TITLE
Debian package updates

### DIFF
--- a/debian/ala-sensitive-data-service.postinst
+++ b/debian/ala-sensitive-data-service.postinst
@@ -33,20 +33,26 @@ case "$1" in
         SPATIAL_URL_ESCAPED=$(printf '%s\n' "$SPATIAL_URL" | sed -e 's/[\/&]/\\&/g')
         sed -i "s/https\:\/\/spatial\.ala\.org\.au/$SPATIAL_URL_ESCAPED/" "$CONF"
 
-        echo "Downloading SDS configs..."
+        echo "Downloading SDS configs..." >&2
         for DEST in sensitive-species-data.xml sensitivity-zones.xml sensitivity-categories.xml
         do
-           curl -sL -o "/data/sds/$DEST" "$SDS_URL/$DEST"
+           curl -sL -o "/data/sds/$DEST" "$SDS_URL/$DEST" || echo "Warning: Failed to download $SDS_URL/$DEST"
         done
-        curl -sf -o /data/sds/layers.json -L "$SDS_URL/ws/layers"
 
-        echo "Downloading SDS layers..."
-        curl -sf -o /data/biocache/layers/sds-layers.tgz -L $LAYERS_URL
+        echo "Downloading SDS layers.json..." >&2
+        curl -sf -o /data/sds/layers.json -L "$SDS_URL/ws/layers" || echo "Warning: Failed to download layers.json"
 
-        echo "Extracting SDS layers..."
-        # SDS def ALA tgz is created with a MacOS tar
-        # https://github.com/yarnpkg/yarn/issues/770
-        tar --no-same-owner --warning=no-unknown-keyword -zxf /data/biocache/layers/sds-layers.tgz -C /data/biocache/layers/
+        echo "Downloading SDS layers.tgz..." >&2
+        curl -sf -o /data/biocache/layers/sds-layers.tgz -L "$LAYERS_URL" || echo "Warning: Failed to download SDS layers tgz"
+
+        if [ -f /data/biocache/layers/sds-layers.tgz ]; then
+          echo "Extracting SDS layers.tgz..." >&2
+          # SDS def ALA tgz is created with a MacOS tar
+          # https://github.com/yarnpkg/yarn/issues/770
+          tar --no-same-owner --warning=no-unknown-keyword -zxf /data/biocache/layers/sds-layers.tgz -C /data/biocache/layers/
+        else
+          echo "Warning: SDS layers tgz not found, skipping extraction"
+        fi
 
         chown -R sds-data:sds-data /opt/atlas/ala-sensitive-data-service
 
@@ -58,4 +64,4 @@ case "$1" in
     ;;
 esac
 
-echo ala-sensitive-data-service installed
+echo ala-sensitive-data-service installed >&2

--- a/debian/control
+++ b/debian/control
@@ -14,8 +14,7 @@ Vcs-Git: https://github.com/AtlasOfLivingAustralia/ala-sensitive-data-service.gi
 
 Package: ala-sensitive-data-service
 Architecture: all
-Depends: ${misc:Depends}, openjdk-8-jdk, ca-certificates, tar (>= 1.0), curl,
- ala-namematching-service
+Depends: ${misc:Depends}, openjdk-8-jdk, ca-certificates, tar (>= 1.0), curl
 Suggests:
 Description: The ALA Sensitive Data Service application
  This package contains the ala-sensitive-data-service package from

--- a/debian/rules
+++ b/debian/rules
@@ -20,7 +20,7 @@ override_dh_auto_build:
 ifeq ($(filter nobuildjar,$(DEB_BUILD_PROFILES)),)
 # This allows to skip the maven jar build (for instance, if its builded by another jenkins job)
 # for instance with debuild -us -uc -b --build-profiles=nobuildjar
-	mvn -Dmaven.repo.local=$(M2_REPO) clean install -DskipTests=true
+	mvn -pl ala-sensitive-data-server -am -Dmaven.repo.local=$(M2_REPO) clean install -DskipTests=true
 endif
 
 override_dh_auto_install:


### PR DESCRIPTION
This pull request introduces several updates to the `ala-sensitive-data-service` debian package, focusing on improving error handling, logging, and build configuration.

### Installation script improvements:
* Enhanced error handling in `debian/ala-sensitive-data-service.postinst` by adding fallback messages when downloads fail (e.g., `layers.json`, `SDS layers tgz`) and skipping extraction if files are missing. Fix for #46 
* Redirected all informational messages to standard error (`>&2`) for better logging consistency.

### Dependency updates:
* Removed the dependency on `ala-namematching-service` in `debian/control`. See: 
https://github.com/AtlasOfLivingAustralia/ala-install/issues/771#issuecomment-1907126139

### Build process adjustments:
* Updated the Maven build command in `debian/rules` to explicitly build the `ala-sensitive-data-server` module.

Installing the package with wrong URLs and failing services that it still installs the package:

```
# dpkg -i ../../ala-sensitive-data-service_1.1-1_all.deb 
(...)
Removing ala-sensitive-data-service
Installing ala-sensitive-data-service
Desempaquetando ala-sensitive-data-service (1.1-1) sobre (1.1-1) ...
ala-sensitive-data-service removed.
Configurando ala-sensitive-data-service (1.1-1) ...
Created symlink /etc/systemd/system/multi-user.target.wants/ala-sensitive-data-service.service → /usr/lib/systemd/system/ala-sensitive-data-service.service.
Downloading SDS configs...
Warning: Failed to download https://sds.gbif.pt/sensitive-species-data.xml
Warning: Failed to download https://sds.gbif.pt/sensitivity-zones.xml
Warning: Failed to download https://sds.gbif.pt/sensitivity-categories.xml
Downloading SDS layers.json...
Warning: Failed to download layers.json
Downloading SDS layers.tgz...
Warning: Failed to download SDS layers tgz
Extracting SDS layers.tgz...
ala-sensitive-data-service installed
```