### PR TITLE
Revert "#54 Make taxonID mandatory - maintenance-1.1 branch"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
-dist: jammy
+dist: trusty
 sudo: required
 language: java
 jdk:
-  - openjdk8
+- oraclejdk8
 branches:
   only:
   - master

--- a/ala-sensitive-data-client/pom.xml
+++ b/ala-sensitive-data-client/pom.xml
@@ -4,8 +4,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>ala-sensitive-data-service</artifactId>
-        <groupId>${this.groupId}</groupId>
-        <version>${this.version}</version>
+        <groupId>au.org.ala.sds</groupId>
+        <version>1.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -19,9 +19,9 @@
             <version>${ala-ws.version}</version>
         </dependency>
         <dependency>
-            <groupId>${this.groupId}</groupId>
+            <groupId>au.org.ala.sds</groupId>
             <artifactId>ala-sensitive-data-core</artifactId>
-            <version>${this.version}</version>
+            <version>${project.version}</version>
         </dependency>
 
         <!-- Test dependencies -->
@@ -38,9 +38,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>${this.groupId}</groupId>
+            <groupId>au.org.ala.sds</groupId>
             <artifactId>ala-sensitive-data-server</artifactId>
-            <version>${this.version}</version>
+            <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -55,9 +55,9 @@
             <version>${slf4j.version}</version>
         </dependency>
         <dependency>
-            <groupId>${this.groupId}</groupId>
+            <groupId>${project.parent.groupId}</groupId>
             <artifactId>ala-sensitive-data-core</artifactId>
-            <version>${this.version}</version>
+            <version>${project.parent.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/ala-sensitive-data-client/src/main/java/au/org/ala/sds/ws/client/ALASDSRetrofitService.java
+++ b/ala-sensitive-data-client/src/main/java/au/org/ala/sds/ws/client/ALASDSRetrofitService.java
@@ -25,11 +25,17 @@ interface ALASDSRetrofitService {
 
     @GET("/api/isSensitive")
     Call<Boolean> isSensitive(
+            @Query("scientificName") String scientificName,
             @Query("taxonId") String taxonId
     );
 
+    @POST("/api/report")
+    @Headers({"Content-Type: application/json"})
+    Call<SensitivityReport> report(@Body SensitivityQuery query);
+
     @GET("/api/report")
      Call<SensitivityReport> report(
+        @Query("scientificName") String scientificName,
         @Query("taxonId") String taxonId,
         @Query("dataResourceUid") String dataResourceUid,
         @Query("stateProvince") String stateProvince,

--- a/ala-sensitive-data-client/src/main/java/au/org/ala/sds/ws/client/ALASDSServiceClient.java
+++ b/ala-sensitive-data-client/src/main/java/au/org/ala/sds/ws/client/ALASDSServiceClient.java
@@ -76,26 +76,40 @@ public class ALASDSServiceClient implements ConservationApi, Closeable {
     /**
      * Test to see whether a taxon is potentially sensitive
      *
+     * @param scientificName The scientific name
      * @param taxonId        The taxon identifier
      * @return True if this species is sensitive in some location
      */
     @Override
-    public boolean isSensitive(String taxonId) {
-        return this.call(this.alaSdsService.isSensitive(taxonId));
+    public boolean isSensitive(String scientificName, String taxonId) {
+        return this.call(this.alaSdsService.isSensitive(scientificName, taxonId));
     }
 
 
     /**
      * Provide a sensitivty report for an occurrence.
      *
+     * @param query The information from the occurrence record.
+     * @return A sensitivitiy report
+     */
+    @Override
+    public SensitivityReport report(SensitivityQuery query) {
+        return this.call(this.alaSdsService.report(query));
+    }
+
+
+    /**
+     * Provide a sensitivty report for an occurrence.
+     *
+     * @param scientificName The scientific name
      * @param taxonId        The taxon identifier
      * @param dataResourceUid The source data resource
      * @param zones          The occurrence record zones
      * @return A sensitivitiy report
      */
     @Override
-    public SensitivityReport report(String taxonId, String dataResourceUid, String stateProvince, String country, List<String> zones) {
-        return this.call(this.alaSdsService.report(taxonId, dataResourceUid, stateProvince, country, zones));
+    public SensitivityReport report(String scientificName, String taxonId, String dataResourceUid, String stateProvince, String country, List<String> zones) {
+        return this.call(this.alaSdsService.report(scientificName, taxonId, dataResourceUid, stateProvince, country, zones));
     }
 
     /**

--- a/ala-sensitive-data-client/src/test/java/au/org/ala/sds/ws/ALASensitiveDataServiceApplicationIT.java
+++ b/ala-sensitive-data-client/src/test/java/au/org/ala/sds/ws/ALASensitiveDataServiceApplicationIT.java
@@ -128,22 +128,21 @@ public class ALASensitiveDataServiceApplicationIT {
 
     @Test
     public void testIsSensitive1() throws Exception {
-        assertTrue(this.client.isSensitive("https://id.biodiversity.org.au/taxon/apni/51412246"));
+        assertTrue(this.client.isSensitive("Pterostylis oreophila", null));
     }
 
     // In normal list but not in reduced list
     @Test
     public void testIsSensitive2() throws Exception {
-        assertFalse(this.client.isSensitive("urn:lsid:biodiversity.org.au:afd.taxon:262fce63-04b3-4f9e-ad61-26798e27ca4c"));
+        assertFalse(this.client.isSensitive("Bertmainius monachus", null));
     }
 
     // Not sensitive
     @Test
     public void testIsSensitive3() throws Exception {
-        assertFalse(this.client.isSensitive("https://id.biodiversity.org.au/taxon/apni/51286863"));
+        assertFalse(this.client.isSensitive("Acacia dealbata", null));
     }
 
-    @Ignore
     @Test
     public void testIsSensitive4() throws Exception {
         SpeciesCheck check = SpeciesCheck.builder().scientificName("Pterostylis oreophila").build();
@@ -152,10 +151,10 @@ public class ALASensitiveDataServiceApplicationIT {
 
     @Test
     public void testGetSensitiveDataFields1() throws Exception {
-        List<String> fields = this.client.getSensitiveDataFields();
-        assertNotNull(fields);
-        assertEquals(38, fields.size());
-        assertEquals("http://rs.tdwg.org/dwc/terms/coordinateUncertaintyInMeters", fields.get(0));
+       List<String> fields = this.client.getSensitiveDataFields();
+       assertNotNull(fields);
+       assertEquals(38, fields.size());
+       assertEquals("http://rs.tdwg.org/dwc/terms/coordinateUncertaintyInMeters", fields.get(0));
     }
 
     @Test
@@ -168,7 +167,7 @@ public class ALASensitiveDataServiceApplicationIT {
 
     @Test
     public void testGetReport1() throws Exception {
-        SensitivityReport report = this.client.report("https://id.biodiversity.org.au/taxon/apni/51412246", null, "Australian Capital Territory", "Australia", null);
+        SensitivityReport report = this.client.report("Pterostylis oreophila", null, null, "Australian Capital Territory", "Australia", null);
         assertNotNull(report);
         assertTrue(report.isSensitive());
     }
@@ -176,14 +175,14 @@ public class ALASensitiveDataServiceApplicationIT {
 
     @Test
     public void testGetReport2() throws Exception {
-        SensitivityReport report = this.client.report("https://id.biodiversity.org.au/taxon/apni/51412246", null, "Victoria", "Australia", null);
+        SensitivityReport report = this.client.report("Pterostylis oreophila", null, null, "Victoria", "Australia", null);
         assertNotNull(report);
         assertFalse(report.isSensitive());
     }
 
     @Test
     public void testGetReport3() throws Exception {
-        SensitivityReport report = this.client.report("Macropius rufus", null, "Victoria", "Australia", null);
+        SensitivityReport report = this.client.report("Macropius rufus", null, null, "Victoria", "Australia", null);
         assertNotNull(report);
         assertFalse(report.isSensitive());
     }
@@ -191,7 +190,7 @@ public class ALASensitiveDataServiceApplicationIT {
     @Test
     public void testGetReport4() throws Exception {
         List<Generalisation> generalisations = this.client.getGeneralisations();
-        SensitivityReport report = this.client.report("https://biodiversity.org.au/afd/taxa/23a8017a-3a2b-4a52-8ca6-d168bf52659c", null, "South Australia", "Australia", null);
+        SensitivityReport report = this.client.report("Pandion haliaetus", null, null, "South Australia", "Australia", null);
         assertNotNull(report);
         assertTrue(report.isSensitive());
         Map<String, String> supplied = new HashMap<>();
@@ -213,7 +212,7 @@ public class ALASensitiveDataServiceApplicationIT {
     @Test
     public void testGetReport5() throws Exception {
         List<Generalisation> generalisations = this.client.getGeneralisations();
-        SensitivityReport report = this.client.report("https://biodiversity.org.au/afd/taxa/23a8017a-3a2b-4a52-8ca6-d168bf52659c", null, "Western Australia", "Australia", null);
+        SensitivityReport report = this.client.report("Pandion haliaetus", null, null, "Western Australia", "Australia", null);
         assertNotNull(report);
         assertTrue(report.isSensitive());
         Map<String, String> supplied = new HashMap<>();

--- a/ala-sensitive-data-client/src/test/java/au/org/ala/sds/ws/client/ALASDSServiceClientTest.java
+++ b/ala-sensitive-data-client/src/test/java/au/org/ala/sds/ws/client/ALASDSServiceClientTest.java
@@ -102,6 +102,7 @@ public class ALASDSServiceClientTest extends TestUtils {
 
         server.enqueue(new MockResponse().setBody(response));
         Boolean sensitive = client.isSensitive(
+            "Varanus semiremex",
             "urn:lsid:biodiversity.org.au:afd.taxon:81244b7e-7145-42fe-b28c-3d672310e739"
         );
         assertNotNull(sensitive);
@@ -109,7 +110,48 @@ public class ALASDSServiceClientTest extends TestUtils {
         assertEquals(1, server.getRequestCount());
         RecordedRequest req = server.takeRequest();
         assertEquals("GET", req.getMethod());
-        assertEquals("/api/isSensitive?taxonId=urn%3Alsid%3Abiodiversity.org.au%3Aafd.taxon%3A81244b7e-7145-42fe-b28c-3d672310e739", req.getPath());
+        assertEquals("/api/isSensitive?scientificName=Varanus%20semiremex&taxonId=urn%3Alsid%3Abiodiversity.org.au%3Aafd.taxon%3A81244b7e-7145-42fe-b28c-3d672310e739", req.getPath());
+    }
+
+    @Test
+    public void testReport1() throws Exception {
+        String request = this.getResource("request-r-1.json");
+        String response = this.getResource("response-r-1.json");
+
+        server.enqueue(new MockResponse().setBody(response));
+        SensitivityQuery query = SensitivityQuery.builder()
+            .scientificName("Varanus semiremex")
+            .taxonId("urn:lsid:biodiversity.org.au:afd.taxon:81244b7e-7145-42fe-b28c-3d672310e739")
+            .stateProvince("Queensland")
+            .country("Australia")
+            .build();
+        SensitivityReport report = client.report(query);
+        assertNotNull(report);
+        assertTrue(report.isValid());
+        assertTrue(report.isSensitive());
+        assertTrue(report.isLoadable());
+        assertFalse(report.isAccessControl());
+        ValidationReport vr = report.getReport();
+        assertNotNull(vr);
+        SensitiveTaxon taxon = vr.getTaxon();
+        assertNotNull(taxon);
+        assertEquals("Varanus semiremex", taxon.getScientificName());
+        assertEquals("urn:lsid:biodiversity.org.au:afd.taxon:81244b7e-7145-42fe-b28c-3d672310e739", taxon.getTaxonId());
+        assertEquals("rusty monitor", taxon.getCommonName());
+        assertNotNull(taxon.getInstances());
+        assertEquals(1, taxon.getInstances().size());
+        SensitivityInstance instance = taxon.getInstances().get(0);
+        assertEquals("Qld DEHP", instance.getAuthority());
+        assertNotNull(instance.getCategory());
+        assertEquals("Sensitive", instance.getCategory().getId());
+        assertEquals("dr493", instance.getDataResourceId());
+        assertNotNull(instance.getZone());
+        assertEquals("QLD", instance.getZone().getId());
+        assertEquals(1, server.getRequestCount());
+        RecordedRequest req = server.takeRequest();
+        assertEquals("POST", req.getMethod());
+        assertEquals("/api/report", req.getPath());
+        assertEquals(request, req.getBody().readUtf8());
     }
 
     @Test
@@ -119,6 +161,7 @@ public class ALASDSServiceClientTest extends TestUtils {
 
         server.enqueue(new MockResponse().setBody(response));
         SensitivityReport report = client.report(
+            "Varanus semiremex",
             "urn:lsid:biodiversity.org.au:afd.taxon:81244b7e-7145-42fe-b28c-3d672310e739",
             "dr6567",
             "Queensland",

--- a/ala-sensitive-data-core/pom.xml
+++ b/ala-sensitive-data-core/pom.xml
@@ -4,8 +4,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>ala-sensitive-data-service</artifactId>
-        <groupId>${this.groupId}</groupId>
-        <version>${this.version}</version>
+        <groupId>au.org.ala.sds</groupId>
+        <version>1.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ala-sensitive-data-core/src/main/java/au/org/ala/sds/api/ConservationApi.java
+++ b/ala-sensitive-data-core/src/main/java/au/org/ala/sds/api/ConservationApi.java
@@ -36,15 +36,34 @@ public interface ConservationApi {
     /**
      * Test to see whether a taxon is potentially sensitive
      *
+     * @param scientificName The scientific name
      * @param taxonId The taxon identifier
      *
      * @return True if this species is sensitive in some location
      */
-    public boolean isSensitive(String taxonId);
+    public boolean isSensitive(String scientificName, String taxonId);
+
+    /**
+     * Provide a sensitivity report based on a taxon and zone.
+     * <p>
+     * Ths method only produces a sensitivity report on the supplied taxon/zones.
+     * To generalise an occurrence record, the report must be applied to an occurrence
+     * record using the generalisation rules.
+     * </p>
+     *
+     * @param query The information from the occurrence record.
+     *
+     * @return A report giving whether the combination of taxon/area is sensitive
+     *
+     * @see #process(ProcessQuery)
+     * @see #getGeneralisations()
+     */
+    public SensitivityReport report(SensitivityQuery query);
 
     /**
      * Provide a sensitivity report based on taxon and zone.
      *
+     * @param scientificName The taxon scientific name
      * @param taxonId The taxon identifier
      * @param dataResourceUid The source data resource for the occurrecne record
      * @param stateProvince The state/province identifier
@@ -53,7 +72,7 @@ public interface ConservationApi {
      *
      * @return A report giving the sensitivity status for that taxon/area
      */
-    public SensitivityReport report(String taxonId, String dataResourceUid, String stateProvince, String country, List<String> zones);
+    public SensitivityReport report(String scientificName, String taxonId, String dataResourceUid, String stateProvince, String country, List<String> zones);
 
     /**
      * Process an occurrence record and supply modified values.

--- a/ala-sensitive-data-core/src/main/java/au/org/ala/sds/api/SensitivityQuery.java
+++ b/ala-sensitive-data-core/src/main/java/au/org/ala/sds/api/SensitivityQuery.java
@@ -24,13 +24,9 @@ import java.util.Map;
     description = "The basic information needed to process an occurrence record, including taxon, broad location and source. "
 )
 public class SensitivityQuery {
-    // The scientificName parameter has been removed. Please use the taxonId parameter instead.
-    // Retained temporarily to return a 400 Bad Request error if a client sends it.
     @ApiModelProperty(
         value = "The scientific name",
-        hidden = true,
         example = "Eucalyptus rossii",
-        notes = "The scientificName parameter has been removed. Please use the taxonId parameter instead.",
         extensions = {
             @Extension(
                 name = "x-reference",
@@ -44,12 +40,10 @@ public class SensitivityQuery {
         }
     )
     @JsonProperty
-    @Deprecated
     private String scientificName;
 
     @ApiModelProperty(
         value = "The taxon identifier",
-        required = true,
         example = "https://id.biodiversity.org.au/node/apni/2900822",
         extensions = {
             @Extension(

--- a/ala-sensitive-data-core/src/main/java/au/org/ala/sds/api/SpeciesCheck.java
+++ b/ala-sensitive-data-core/src/main/java/au/org/ala/sds/api/SpeciesCheck.java
@@ -21,13 +21,9 @@ import lombok.Value;
         "Information on a potential species match, both name and, if available, the taxon identifier"
 )
 public class SpeciesCheck {
-    // The scientificName parameter has been removed. Please use the taxonId parameter instead.
-    // Retained temporarily to return a 400 Bad Request error if a client sends it.
     @ApiModelProperty(
         value = "The scientific name",
-        hidden = true,
         example = "Eucalyptus rossii",
-        notes = "The scientificName parameter has been removed. Please use the taxonId parameter instead.",
         extensions = {
            @Extension(
                name = "x-reference",
@@ -41,11 +37,9 @@ public class SpeciesCheck {
         }
     )
     @JsonProperty
-    @Deprecated
     private String scientificName;
     @ApiModelProperty(
         value = "The taxon identifier",
-        required = true,
         example = "https://id.biodiversity.org.au/node/apni/2900822",
         extensions = {
             @Extension(

--- a/ala-sensitive-data-server/config.yml
+++ b/ala-sensitive-data-server/config.yml
@@ -24,7 +24,7 @@ conservation:
   speciesUrl: https://sds.ala.org.au/sensitive-species-data.xml
   zonesUrl: https://sds.ala.org.au/sensitivity-zones.xml
   categoriesUrl: https://sds.ala.org.au/sensitivity-categories.xml
-  layersUrl: https://sensitive-ws.ala.org.au/ws/layers
+  layersUrl: https://sds.ala.org.au/ws/layers
   layersServiceUrl: https://spatial.ala.org.au/layers-service
   cache:
     entryCapacity: 10000

--- a/ala-sensitive-data-server/docker/Dockerfile-test
+++ b/ala-sensitive-data-server/docker/Dockerfile-test
@@ -28,7 +28,7 @@ RUN tar zxf /data/biocache/layers/sds-layers.tgz -C /data/biocache/layers/
 RUN curl -sf -o /data/sds/sensitive-species-data.xml -L https://sds.ala.org.au/sensitive-species-data.xml
 RUN curl -sf -o /data/sds/sensitivity-zones.xml -L https://sds.ala.org.au/sensitivity-zones.xml
 RUN curl -sf -o /data/sds/sensitivity-categories.xml -L https://sds.ala.org.au/sensitivity-categories.xml
-RUN curl -sf -o /data/sds/layers.json -L https://sensitive-ws.ala.org.au/ws/layers
+RUN curl -sf -o /data/sds/layers.json -L https://sds.ala.org.au/ws/layers
 
 EXPOSE 9189
 EXPOSE 9190

--- a/ala-sensitive-data-server/pom.xml
+++ b/ala-sensitive-data-server/pom.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>ala-sensitive-data-service</artifactId>
-        <groupId>${this.groupId}</groupId>
-        <version>${this.version}</version>
+        <groupId>au.org.ala.sds</groupId>
+        <version>1.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -18,9 +18,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>${this.groupId}</groupId>
+            <groupId>${project.parent.groupId}</groupId>
             <artifactId>ala-sensitive-data-core</artifactId>
-        <version>${this.version}</version>
+            <version>${project.parent.version}</version>
         </dependency>
 
         <dependency>
@@ -78,9 +78,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>${this.groupId}</groupId>
+            <groupId>${project.parent.groupId}</groupId>
             <artifactId>ala-sensitive-data-core</artifactId>
-            <version>${this.version}</version>
+            <version>${project.parent.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/ala-sensitive-data-server/src/main/java/au/org/ala/sds/ws/core/SDSConfiguration.java
+++ b/ala-sensitive-data-server/src/main/java/au/org/ala/sds/ws/core/SDSConfiguration.java
@@ -48,13 +48,10 @@ public class SDSConfiguration {
     private List<String> layers = null;
     /** Source of spatial layers, used if there isn't a specific list of layers (a JSON file) */
     @JsonProperty
-    private String layersUrl = "https://sensitive-ws.ala.org.au/ws/layers";
-    /** Source of layer information */
+    private String layersUrl = "https://sds.ala.org.au/ws/layers";
+    /** The source of layer information */
     @JsonProperty
     private String layersServiceUrl = "https://spatial.ala.org.au/layers-service";
-    /** The URL of the name matching service */
-    @JsonProperty
-    private String nameMatchingServiceUrl = "https://namematching-ws.ala.org.au/swagger";
     /** The cache configuration */
     @JsonProperty
     private CacheConfiguration cache = new CacheConfiguration();

--- a/ala-sensitive-data-server/src/main/java/au/org/ala/sds/ws/resources/ConservationResource.java
+++ b/ala-sensitive-data-server/src/main/java/au/org/ala/sds/ws/resources/ConservationResource.java
@@ -103,7 +103,7 @@ public class ConservationResource implements ConservationApi, Closeable, Checkab
         DwcTerm.infraspecificEpithet,
         TermFactory.instance().findTerm("intraspecificEpithet") // Misspelling
     ));
-
+    
     /** Name searcher */
     private final ALANameSearcher searcher;
     /** Find sensitive species */
@@ -116,8 +116,6 @@ public class ConservationResource implements ConservationApi, Closeable, Checkab
     private List<Generalisation> generalisations;
     /** The list of terms to request */
     private Set<Term> requestTerms;
-    /** The URL of the name matching service */
-    private String nameMatchingServiceUrl;
 
     //Cache2k instance
     private final Cache<SpeciesCheck, Boolean> isSensitiveCache;
@@ -130,7 +128,6 @@ public class ConservationResource implements ConservationApi, Closeable, Checkab
             this.sds = new SensitiveDataService();
             this.translator = new ApiTranslator(false);
             this.generalisations = configuration.getGeneralisations();
-            this.nameMatchingServiceUrl = configuration.getNameMatchingServiceUrl();
             this.isSensitiveCache = configuration.getCache().builder(SpeciesCheck.class, Boolean.class)
                     .loader(new CacheLoader<SpeciesCheck, Boolean>() {
                         @Override
@@ -144,7 +141,7 @@ public class ConservationResource implements ConservationApi, Closeable, Checkab
             throw new RuntimeException("Unable to initialise searcher: " + e.getMessage(), e);
         }
         this.requestTerms = this.buildRequestTerms();
-    }
+     }
 
     /**
      * Build the list of terms that might be needed.
@@ -152,19 +149,19 @@ public class ConservationResource implements ConservationApi, Closeable, Checkab
      * @return A set of terms that get used somewhere
      */
     protected Set<Term> buildRequestTerms() {
-        TermFactory factory = TermFactory.instance();
-        Set<Term> fields = new HashSet<>();
-        Configuration config = Configuration.getInstance();
-        for (String flag: config.getFlagRules().split(",")) {
-            fields.add(factory.findTerm(flag));
-        }
-        for (Generalisation generalisation: this.generalisations)
-            fields.addAll(generalisation.getFields().stream().map(FieldAccessor::getField).collect(Collectors.toSet()));
-        for (String fact: FactCollection.FACT_NAMES) {
-            fields.add(factory.findTerm(fact));
-        }
-        return fields;
-    }
+         TermFactory factory = TermFactory.instance();
+         Set<Term> fields = new HashSet<>();
+         Configuration config = Configuration.getInstance();
+         for (String flag: config.getFlagRules().split(",")) {
+             fields.add(factory.findTerm(flag));
+         }
+         for (Generalisation generalisation: this.generalisations)
+             fields.addAll(generalisation.getFields().stream().map(FieldAccessor::getField).collect(Collectors.toSet()));
+         for (String fact: FactCollection.FACT_NAMES) {
+             fields.add(factory.findTerm(fact));
+         }
+         return fields;
+     }
 
     /**
      * Make sure that the system is still operating.
@@ -203,46 +200,35 @@ public class ConservationResource implements ConservationApi, Closeable, Checkab
     }
 
     @ApiOperation(
-        value = "Check to see if a species is potentially sensitive",
-        notes = "Note: The scientificName parameter has been removed. Please use the taxonId parameter. To obtain a taxonId for a given scientific name, use the ALA Name Matching service."
+            value = "Check to see if a species is potentially sensitive",
+            notes = "Search based on a species name or taxon and see whether it is in the list of potentially sensitive species. " +
+                    "Sensitive species declarations are based on geography; this method simply indicates whether a species might be classified as sensitive."
     )
     @POST
     @Timed
     @Path("/isSensitive")
     public boolean isSensitive(SpeciesCheck check) {
-        validateScientificNameRemoved(check.getScientificName());
-        validateTaxonIdRequired(check.getTaxonId());
         try {
-            SpeciesCheck normalized = SpeciesCheck.builder()
-                .scientificName(check.getScientificName())
-                .taxonId(normalizeTaxonId(check.getTaxonId()))
-                .build();
-            return this.isSensitiveCache.get(normalized);
+            return this.isSensitiveCache.get(check);
         } catch (Exception e){
-            log.warn("Problem checking species : " + e.getMessage() + " with species: " + check);
+            log.warn("Problem cheking species : " + e.getMessage() + " with specices: " + check);
             throw e;
         }
     }
 
-    public boolean isSensitive(String taxonId) {
-        validateTaxonIdRequired(taxonId);
-        return this.isSensitive(SpeciesCheck.builder().taxonId(normalizeTaxonId(taxonId)).build());
-    }
-
     @ApiOperation(
         value = "Check to see if a species is potentially sensitive",
-        notes = "Note: The scientificName parameter has been removed. Please use the taxonId parameter. To obtain a taxonId for a given scientific name, use the ALA Name Matching service."
+        notes = "Search based on a species name or taxon and see whether it is in the list of potentially sensitive species. " +
+            "Sensitive species declarations are based on geography; this method simply indicates whether a species might be classified as sensitive."
     )
     @GET
     @Timed
     @Path("/isSensitive")
     public boolean isSensitive(
-        @QueryParam("scientificName") String scientificName,
-        @ApiParam(value = "The taxonomic identifier for the taxon", required = true) @QueryParam("taxonId") String taxonId
+        @ApiParam(value = "The scientific name of the taxon", required = true, example = "Acacia dealbata") @QueryParam("scientificName") String scientificName,
+        @ApiParam(value = "The taxonomc identifier for the taxon") @QueryParam("taxonId") String taxonId
     ) {
-        validateScientificNameRemoved(scientificName);
-        validateTaxonIdRequired(taxonId);
-        SpeciesCheck check = SpeciesCheck.builder().taxonId(normalizeTaxonId(taxonId)).build();
+        SpeciesCheck check = SpeciesCheck.builder().scientificName(scientificName).taxonId(taxonId).build();
         return this.isSensitive(check);
     }
 
@@ -259,14 +245,14 @@ public class ConservationResource implements ConservationApi, Closeable, Checkab
 
     @ApiOperation(
         value = "Provide a sensitivity report for a taxon/zone combination.",
-        notes = "Note: The scientificName parameter has been removed. Please use the taxonId parameter. To obtain a taxonId for a given scientific name, use the ALA Name Matching service."
+        notes = "This provides a report on whether the combination of taxon/zone/data resource is sensitive or not and the sensitivity instances. " +
+          "The resulting report can be used, in combination with the list of generalisations, to process an occurrence."
     )
     @POST
     @Path("/report")
     public SensitivityReport report(SensitivityQuery query) {
-        validateScientificNameRemoved(query.getScientificName());
-        validateTaxonIdRequired(query.getTaxonId());
         return this.report(
+            query.getScientificName(),
             query.getTaxonId(),
             query.getDataResourceUid(),
             query.getStateProvince(),
@@ -275,26 +261,21 @@ public class ConservationResource implements ConservationApi, Closeable, Checkab
         );
     }
 
-    public SensitivityReport report(String taxonId, String dataResourceUid, String stateProvince, String country, List<String> zones) {
-        return this.report(null, normalizeTaxonId(taxonId), dataResourceUid, stateProvince, country, zones);
-    }
-
     @ApiOperation(
         value = "Provide a sensitivity report for a taxon/zone combination.",
-        notes = "Note: The scientificName parameter has been removed. Please use the taxonId parameter. To obtain a taxonId for a given scientific name, use the ALA Name Matching service."
+        notes = "This provides a report on whether the combination of taxon/zone/data resource is sensitive or not and the sensitivity instances. " +
+            "The resulting report can be used, in combination with the list of generalisations, to process an occurrence."
     )
     @GET
     @Path("/report")
     public SensitivityReport report(
-        @QueryParam("scientificName") String scientificName,
-        @ApiParam(value = "The taxon identifier", required = true, example = "https://id.biodiversity.org.au/node/apni/2914286") @QueryParam("taxonId")String taxonId,
+        @ApiParam(value = "The scientific name of the taxon", required = true, example = "Psilotum complanatum") @QueryParam("scientificName") String scientificName,
+        @ApiParam(value = "The taxon identifier", example = "https://id.biodiversity.org.au/node/apni/2914286") @QueryParam("taxonId")String taxonId,
         @ApiParam(value = "The source data resource identifier", example = "dr1654") @QueryParam("dataResourceUid")String dataResourceUid,
         @ApiParam(value = "The state or province zone identifier", example = "NSW") @QueryParam("stateProvince") String stateProvince,
         @ApiParam(value = "The country zone identifier", example = "AUS") @QueryParam("country") String country,
-        @ApiParam(value = "The zone identifiers ", allowMultiple = true, example = "FFEZ") @QueryParam("zone") List<String> zones) {
-        validateScientificNameRemoved(scientificName);
-        validateTaxonIdRequired(taxonId);
-        taxonId = normalizeTaxonId(taxonId);
+        @ApiParam(value = "The zone identifiers ", allowMultiple = true, example = "FFEZ") @QueryParam("zone") List<String> zones
+    ) {
         Map<String, String> properties = new HashMap<>();
         properties.put("samplesProvided", "yes");
         if (dataResourceUid != null && !dataResourceUid.isEmpty())
@@ -318,13 +299,11 @@ public class ConservationResource implements ConservationApi, Closeable, Checkab
 
     @ApiOperation(
         value = "Process occurrence properties for a sensitive species",
-        notes = "Note: The scientificName parameter has been removed. Please use the taxonId parameter. To obtain a taxonId for a given scientific name, use the ALA Name Matching service."
+        notes = "Applies the sensitivity processing rules for a sensitive species to properties from an occurrence record."
     )
     @POST
     @Path("/process")
     public SensitivityReport process(ProcessQuery query) {
-        validateScientificNameRemoved(query.getScientificName());
-        validateTaxonIdRequired(query.getTaxonId());
         Map<String, String> properties = new HashMap<>(query.getProperties());
         // Ensure key facts are present in the way expected
         for (String fact: FactCollection.FACT_NAMES) {
@@ -343,7 +322,7 @@ public class ConservationResource implements ConservationApi, Closeable, Checkab
             this.finder,
             properties,
             query.getScientificName(),
-            normalizeTaxonId(query.getTaxonId())
+            query.getTaxonId()
         );
         this.amendOutcome(query, outcome);
         SensitivityReport report = this.translator.buildSensitivityReport(outcome, false);
@@ -358,25 +337,6 @@ public class ConservationResource implements ConservationApi, Closeable, Checkab
      */
     @Override
     public void close()  {
-    }
-
-    private void validateScientificNameRemoved(String scientificName) {
-        if (StringUtils.isNotEmpty(scientificName)) {
-            throw new BadRequestException("The scientificName parameter has been removed. Please use the taxonId parameter instead. To obtain a taxonId for a given scientific name, use the ALA Name Matching API: " + this.nameMatchingServiceUrl);
-        }
-    }
-
-    private void validateTaxonIdRequired(String taxonId) {
-        if (StringUtils.isBlank(taxonId)) {
-            throw new BadRequestException("The taxonId parameter is required.");
-        }
-    }
-
-    private String normalizeTaxonId(String taxonId) {
-        if (StringUtils.startsWith(taxonId, "http://id.biodiversity.org.au/") || StringUtils.startsWith(taxonId, "http://biodiversity.org.au/")) {
-            return "https://" + taxonId.substring("http://".length());
-        }
-        return taxonId;
     }
 
     /**

--- a/ala-sensitive-data-server/src/test/java/au/org/ala/sds/ws/resources/ConservationResourceTest.java
+++ b/ala-sensitive-data-server/src/test/java/au/org/ala/sds/ws/resources/ConservationResourceTest.java
@@ -62,40 +62,37 @@ public class ConservationResourceTest {
     @Test
     public void testIsSensitiveCheck1() throws Exception {
         SpeciesCheck check;
-        // Acacia dealbata -> https://id.biodiversity.org.au/taxon/apni/51286863
-        check = SpeciesCheck.builder().taxonId("https://id.biodiversity.org.au/taxon/apni/51286863").build();
+        check = SpeciesCheck.builder().scientificName("Acacia dealbata").build();
         assertFalse(resource.isSensitive(check));
-        // Caesia talingka -> https://id.biodiversity.org.au/name/apni/50620826
-        check = SpeciesCheck.builder().taxonId("https://id.biodiversity.org.au/name/apni/50620826").build();
+        check = SpeciesCheck.builder().scientificName("Caesia talingka").build();
         assertTrue(resource.isSensitive(check));
-        // Caesia sp. Koolanooka Hills -> ALA_DR2201_2911
-        check = SpeciesCheck.builder().taxonId("ALA_DR2201_2911").build();
+        check = SpeciesCheck.builder().scientificName("Caesia sp. Koolanooka Hills (R. Meissner & Y. Caruso 78)").build();
         assertTrue(resource.isSensitive(check));
     }
 
     @Test
     public void testIsSensitiveCheck2() throws Exception {
         SpeciesCheck check;
-        check = SpeciesCheck.builder().taxonId("https://id.biodiversity.org.au/taxon/apni/51286863").build();
+        check = SpeciesCheck.builder().scientificName("Acacia dealbata").taxonId("https://id.biodiversity.org.au/taxon/apni/51286863").build();
         assertFalse(resource.isSensitive(check));
-        check = SpeciesCheck.builder().taxonId("https://id.biodiversity.org.au/node/apni/2914477").build();
+        check = SpeciesCheck.builder().scientificName("Thryptomene stenophylla").taxonId("http://id.biodiversity.org.au/node/apni/2914477").build();
         assertTrue(resource.isSensitive(check));
-        check = SpeciesCheck.builder().taxonId("ALA_DR2201_2911").build();
+        check = SpeciesCheck.builder().scientificName("Caesia sp. Koolanooka Hills (R. Meissner & Y. Caruso 78)").taxonId("ALA_Caesia_sp_Koolanooka_Hills_R_Meissner_Y_Caruso_78").build();
         assertTrue(resource.isSensitive(check));
-        check = SpeciesCheck.builder().taxonId("Some random junk").build();
-        assertFalse(resource.isSensitive(check));
+        check = SpeciesCheck.builder().scientificName("Thryptomene stenophylla").taxonId("Some random junk").build();
+        assertTrue(resource.isSensitive(check));
     }
 
     @Test
     public void testIsSensitive1() throws Exception {
-        assertFalse(resource.isSensitive(null, "https://id.biodiversity.org.au/taxon/apni/51286863"));
-        assertTrue(resource.isSensitive(null, "http://id.biodiversity.org.au/node/apni/2914477"));
+        assertFalse(resource.isSensitive("Acacia dealbata", "https://id.biodiversity.org.au/taxon/apni/51286863"));
+        assertTrue(resource.isSensitive("Thryptomene stenophylla", "http://id.biodiversity.org.au/node/apni/2914477"));
     }
 
 
     @Test
     public void testReport1() throws Exception {
-        SensitivityQuery query = SensitivityQuery.builder().taxonId("https://id.biodiversity.org.au/node/apni/2914499").stateProvince("Western Australia").country("Australia").build();
+        SensitivityQuery query = SensitivityQuery.builder().scientificName("Eucalyptus sparsa").stateProvince("Western Australia").country("Australia").build();
         SensitivityReport report = resource.report(query);
         assertNotNull(report);
         assertTrue(report.isValid());
@@ -123,7 +120,7 @@ public class ConservationResourceTest {
 
     @Test
     public void testReport2() throws Exception {
-        SensitivityReport report = resource.report(null, "https://id.biodiversity.org.au/node/apni/2914499", null, "Western Australia", "Australia", null);
+        SensitivityReport report = resource.report("Eucalyptus sparsa", null, null, "Western Australia", "Australia", null);
         assertNotNull(report);
         assertTrue(report.isValid());
         assertTrue(report.isSensitive());
@@ -152,7 +149,7 @@ public class ConservationResourceTest {
     // Weird Birdlife special case
     @Test
     public void testReport3() throws Exception {
-        SensitivityReport report = resource.report(null, "https://biodiversity.org.au/afd/taxa/480b034f-0774-4cc5-9aa2-d31a3cb6cd30", "dr359", "South Australia", "Australia", null);
+        SensitivityReport report = resource.report("Neochmia phaeton", null, "dr359", "South Australia", "Australia", null);
         assertNotNull(report);
         assertTrue(report.isValid());
         assertTrue(report.isSensitive());
@@ -181,7 +178,7 @@ public class ConservationResourceTest {
     // Weird Birdlife special case (data resource different)
     @Test
     public void testReport4() throws Exception {
-        SensitivityReport report = resource.report(null, "https://biodiversity.org.au/afd/taxa/480b034f-0774-4cc5-9aa2-d31a3cb6cd30", "dr8359", "South Australia", "Australia", null);
+        SensitivityReport report = resource.report("Neochmia phaeton", null, "dr8359", "South Australia", "Australia", null);
         assertNotNull(report);
         assertTrue(report.isValid());
         assertFalse(report.isSensitive());
@@ -193,7 +190,7 @@ public class ConservationResourceTest {
     // Test taxon with multiple instances
     @Test
     public void testReport5() throws Exception {
-        SensitivityReport report = resource.report(null, "ALA_DR652_1667", null, "Queensland", "Australia", null);
+        SensitivityReport report = resource.report("Pandion haliaetus", null, "dr8359", "Western Australia", "Australia", null);
         assertNotNull(report);
         assertTrue(report.isValid());
         assertTrue(report.isSensitive());
@@ -203,26 +200,26 @@ public class ConservationResourceTest {
         assertNotNull(vr);
         SensitiveTaxon taxon = vr.getTaxon();
         assertNotNull(taxon);
-        assertEquals("Sarcochilus loganii", taxon.getScientificName());
-        assertEquals("ALA_DR652_1667", taxon.getTaxonId());
+        assertEquals("Pandion haliaetus", taxon.getScientificName());
+        assertEquals("https://biodiversity.org.au/afd/taxa/23a8017a-3a2b-4a52-8ca6-d168bf52659c", taxon.getTaxonId());
         assertNotNull(taxon.getInstances());
         assertEquals(1, taxon.getInstances().size());
         SensitivityInstance instance = taxon.getInstances().get(0);
-        assertEquals("Qld DEHP", instance.getAuthority());
+        assertEquals("WA DEC", instance.getAuthority());
         assertEquals(SensitivityInstance.SensitivityType.CONSERVATION, instance.getType());
         assertEquals("10km", instance.getGeneralisation().getGeneralisation());
         assertNotNull(instance.getCategory());
         assertEquals("Sensitive", instance.getCategory().getId());
-        assertEquals("dr493", instance.getDataResourceId());
+        assertEquals("dr467", instance.getDataResourceId());
         assertNotNull(instance.getZone());
-        assertEquals("QLD", instance.getZone().getId());
+        assertEquals("WA", instance.getZone().getId());
     }
 
 
     // Test taxon with multiple instances - only one requested
     @Test
     public void testReport6() throws Exception {
-        SensitivityReport report = resource.report(null, "https://biodiversity.org.au/afd/taxa/23a8017a-3a2b-4a52-8ca6-d168bf52659c", "dr1411", "South Australia", "Australia", null);
+        SensitivityReport report = resource.report("Pandion haliaetus", null, "dr8359", "South Australia", "Australia", null);
         assertNotNull(report);
         assertTrue(report.isValid());
         assertTrue(report.isSensitive());
@@ -250,14 +247,20 @@ public class ConservationResourceTest {
     // Test taxon with multiple instances - only one requested
     @Test
     public void testReport7() throws Exception {
-        SensitivityReport report = resource.report(null, "some-random-id", "dr1411", "Victoria", "Australia", null);
+        SensitivityReport report = resource.report("Pandion haliaetus", null, "dr8359", "Tasmania", "Australia", null);
         assertNotNull(report);
         assertTrue(report.isValid());
         assertFalse(report.isSensitive());
         assertTrue(report.isLoadable());
         assertFalse(report.isAccessControl());
         ValidationReport vr = report.getReport();
-        assertNull(vr);
+        assertNotNull(vr);
+        SensitiveTaxon taxon = vr.getTaxon();
+        assertNotNull(taxon);
+        assertEquals("Pandion haliaetus", taxon.getScientificName());
+        assertEquals("https://biodiversity.org.au/afd/taxa/23a8017a-3a2b-4a52-8ca6-d168bf52659c", taxon.getTaxonId());
+        assertNotNull(taxon.getInstances());
+        assertEquals(0, taxon.getInstances().size());
     }
 
     @Test
@@ -266,7 +269,7 @@ public class ConservationResourceTest {
         properties.put(DwcTerm.decimalLatitude.qualifiedName(), "-33.757122");
         properties.put(DwcTerm.decimalLongitude.qualifiedName(), "121.9266423");
         properties.put(DwcTerm.eventDate.qualifiedName(), "2020-08-14");
-        ProcessQuery query = ProcessQuery.builder().taxonId("http://id.biodiversity.org.au/node/apni/2914499").properties(properties).build();
+        ProcessQuery query = ProcessQuery.builder().scientificName("Eucalyptus sparsa").properties(properties).build();
         SensitivityReport report = resource.process(query);
         assertNotNull(report);
         assertTrue(report.isValid());
@@ -303,7 +306,7 @@ public class ConservationResourceTest {
         properties.put(FactCollection.DECIMAL_LATITUDE_KEY, "-27.327739");
         properties.put(FactCollection.DECIMAL_LONGITUDE_KEY, "152.527914");
         properties.put(FactCollection.EVENT_DATE_KEY, "1990-04-12");
-        ProcessQuery query = ProcessQuery.builder().taxonId("https://biodiversity.org.au/afd/taxa/2edc1a0c-b74a-49da-b053-b7e1328a54a7").properties(properties).build();
+        ProcessQuery query = ProcessQuery.builder().scientificName("Litoria lorica").taxonId("urn:lsid:biodiversity.org.au:afd.taxon:8002722e-d0f8-4de2-af61-5cba07d44cd2").properties(properties).build();
         SensitivityReport report = resource.process(query);
         assertNotNull(report);
         assertTrue(report.isValid());
@@ -343,7 +346,7 @@ public class ConservationResourceTest {
         properties.put(FactCollection.DECIMAL_LATITUDE_KEY, "-26.453510");
         properties.put(FactCollection.DECIMAL_LONGITUDE_KEY, "114.653393");
         properties.put(FactCollection.EVENT_DATE_KEY, "1990-04-12");
-        ProcessQuery query = ProcessQuery.builder().taxonId("https://biodiversity.org.au/afd/taxa/2edc1a0c-b74a-49da-b053-b7e1328a54a7").properties(properties).build();
+        ProcessQuery query = ProcessQuery.builder().scientificName("Litoria lorica").taxonId("urn:lsid:biodiversity.org.au:afd.taxon:8002722e-d0f8-4de2-af61-5cba07d44cd2").properties(properties).build();
         SensitivityReport report = resource.process(query);
         assertNotNull(report);
         assertTrue(report.isValid());
@@ -366,93 +369,4 @@ public class ConservationResourceTest {
         assertNull(result.get("generalisationInMetres"));
     }
 
-    @Test
-    public void testProcess4() throws Exception {
-        Map<String, String> properties = new HashMap<>();
-        properties.put(DwcTerm.decimalLatitude.qualifiedName(), "-25.553383018953113");
-        properties.put(DwcTerm.decimalLongitude.qualifiedName(), "152.25753300000002");
-        properties.put(DwcTerm.eventDate.qualifiedName(), "2006-08-22");
-        ProcessQuery query = ProcessQuery.builder().taxonId("ALA_DR652_1667").properties(properties).build();
-        SensitivityReport report = resource.process(query);
-        assertNotNull(report);
-        assertTrue(report.isValid());
-        assertTrue(report.isSensitive());
-        assertTrue(report.isLoadable());
-        assertFalse(report.isAccessControl());
-        ValidationReport vr = report.getReport();
-        assertNotNull(vr);
-        SensitiveTaxon taxon = vr.getTaxon();
-        assertNotNull(taxon);
-        assertEquals("Sarcochilus loganii", taxon.getScientificName());
-        assertEquals("ALA_DR652_1667", taxon.getTaxonId());
-        assertNotNull(taxon.getInstances());
-        assertEquals(1, taxon.getInstances().size());
-        SensitivityInstance instance = taxon.getInstances().get(0);
-        assertEquals("Qld DEHP", instance.getAuthority());
-        assertEquals(SensitivityInstance.SensitivityType.CONSERVATION, instance.getType());
-        assertEquals("10km", instance.getGeneralisation().getGeneralisation());
-        assertNotNull(instance.getCategory());
-        assertEquals("Sensitive", instance.getCategory().getId());
-        assertEquals("dr493", instance.getDataResourceId());
-        assertNotNull(instance.getZone());
-        assertEquals("QLD", instance.getZone().getId());
-        Map<String, Object> result = report.getUpdated();
-        assertNotNull(result);
-        assertEquals("152.3", result.get(DwcTerm.decimalLongitude.qualifiedName()));
-        assertEquals("-25.6", result.get(DwcTerm.decimalLatitude.qualifiedName()));
-        assertEquals("10000", result.get(DwcTerm.coordinateUncertaintyInMeters.simpleName()));
-    }
-
-    @Test
-    public void testValidationScientificNameRejected() throws Exception {
-        try {
-            resource.isSensitive("Eucalyptus", "taxon1");
-            fail("Expected BadRequestException");
-        } catch (javax.ws.rs.BadRequestException ex) {
-            assertTrue(ex.getMessage().contains("scientificName parameter has been removed"));
-        }
-        try {
-            resource.report("Eucalyptus", "taxon1", null, null, null, null);
-            fail("Expected BadRequestException");
-        } catch (javax.ws.rs.BadRequestException ex) {
-            assertTrue(ex.getMessage().contains("scientificName parameter has been removed"));
-        }
-        try {
-            SpeciesCheck check = SpeciesCheck.builder().scientificName("Eucalyptus").taxonId("taxon1").build();
-            resource.isSensitive(check);
-            fail("Expected BadRequestException");
-        } catch (javax.ws.rs.BadRequestException ex) {
-            assertTrue(ex.getMessage().contains("scientificName parameter has been removed"));
-        }
-        try {
-            ProcessQuery query = ProcessQuery.builder().scientificName("Eucalyptus").taxonId("taxon1").build();
-            resource.process(query);
-            fail("Expected BadRequestException");
-        } catch (javax.ws.rs.BadRequestException ex) {
-            assertTrue(ex.getMessage().contains("scientificName parameter has been removed"));
-        }
-    }
-
-    @Test
-    public void testValidationTaxonIdRequired() throws Exception {
-        try {
-            resource.isSensitive(null, null);
-            fail("Expected BadRequestException");
-        } catch (javax.ws.rs.BadRequestException ex) {
-            assertTrue(ex.getMessage().contains("taxonId parameter is required"));
-        }
-        try {
-            resource.report(null, "", null, null, null, null);
-            fail("Expected BadRequestException");
-        } catch (javax.ws.rs.BadRequestException ex) {
-            assertTrue(ex.getMessage().contains("taxonId parameter is required"));
-        }
-        try {
-            SpeciesCheck check = SpeciesCheck.builder().build();
-            resource.isSensitive(check);
-            fail("Expected BadRequestException");
-        } catch (javax.ws.rs.BadRequestException ex) {
-            assertTrue(ex.getMessage().contains("taxonId parameter is required"));
-        }
-    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <modules>
         <module>ala-sensitive-data-core</module>
@@ -15,32 +15,10 @@
         <version>14</version>
     </parent>
 
-    <properties>
-        <this.groupId>au.org.ala.sds</this.groupId>
-        <this.version>1.1.2-SNAPSHOT</this.version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <sds.version>1.4.9</sds.version>
-        <dwc-api.version>1.27</dwc-api.version>
-        <ala-name-matching.version>4.3</ala-name-matching.version>
-        <cache2k.version>1.2.0.Final</cache2k.version>
-        <jackson.version>2.10.4</jackson.version>
-        <retrofit.version>2.6.2</retrofit.version>
-        <okhttp.version>4.3.1</okhttp.version>
-        <dropwizard.version>2.0.11</dropwizard.version>
-        <dropwizard-swagger.version>2.0.0-1</dropwizard-swagger.version> <!-- Can't use 2.0.12-1 method not found -->
-        <dropwizard-redirect-bundle.version>1.3.5</dropwizard-redirect-bundle.version>
-        <swagger.version>1.6.0</swagger.version> <!-- Compatibility with dropwizard-swagger 2.0.0-1 -->
-        <slf4j.version>1.7.5</slf4j.version>
-        <log4j.version>2.13.2</log4j.version>
-        <kotlin-stdlib.version>1.3.50</kotlin-stdlib.version>
-        <lombok.version>1.18.28</lombok.version>
-        <ala-ws.version>1.7</ala-ws.version>
-    </properties>
 
-    <groupId>${this.groupId}</groupId>
+    <groupId>au.org.ala.sds</groupId>
     <artifactId>ala-sensitive-data-service</artifactId>
-    <version>${this.version}</version>
+    <version>1.1.1</version>
     <packaging>pom</packaging>
 
     <name>ALA Sensitive Data Service</name>
@@ -67,6 +45,27 @@
             <url>https://www.mozilla.org/en-US/MPL/1.1/</url>
         </license>
     </licenses>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <sds.version>1.4.9</sds.version>
+        <dwc-api.version>1.27</dwc-api.version>
+        <ala-name-matching.version>4.3</ala-name-matching.version>
+        <cache2k.version>1.2.0.Final</cache2k.version>
+        <jackson.version>2.10.4</jackson.version>
+        <retrofit.version>2.6.2</retrofit.version>
+        <okhttp.version>4.3.1</okhttp.version>
+        <dropwizard.version>2.0.11</dropwizard.version>
+        <dropwizard-swagger.version>2.0.0-1</dropwizard-swagger.version> <!-- Can't use 2.0.12-1 method not found -->
+        <dropwizard-redirect-bundle.version>1.3.5</dropwizard-redirect-bundle.version>
+        <swagger.version>1.6.0</swagger.version> <!-- Compatibility with dropwizard-swagger 2.0.0-1 -->
+        <slf4j.version>1.7.5</slf4j.version>
+        <log4j.version>2.13.2</log4j.version>
+        <kotlin-stdlib.version>1.3.50</kotlin-stdlib.version>
+        <lombok.version>1.18.28</lombok.version>
+        <ala-ws.version>1.7</ala-ws.version>
+    </properties>
 
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
Reverts AtlasOfLivingAustralia/ala-sensitive-data-service#57

See [this comment](https://github.com/AtlasOfLivingAustralia/ala-sensitive-data-service/issues/54#issuecomment-4976193648) for justification and details.